### PR TITLE
docs: drop a dangling spec reference from the mls-external-rejoin summary

### DIFF
--- a/docs/agents/plans/completed/2026-04-20-mls-external-rejoin.complete.md
+++ b/docs/agents/plans/completed/2026-04-20-mls-external-rejoin.complete.md
@@ -29,7 +29,9 @@ Add RFC 9420 external-commit support to `@enkaku/group`, scoped to the stale-dev
 
 ## Scope Notes
 
-Design-review phase resolved seven tradeoff questions before planning began; those resolutions are captured in the spec (`docs/superpowers/specs/2026-04-20-mls-external-rejoin-design.md`) and informed the plan decisions above. Two rounds of code review post-implementation: an initial round flagged three Important issues (unnecessary cast, weak codec-test, ambiguous README wording); all three fixed in `cdbfd27`. Final pre-merge review: approved.
+A design-review phase resolved seven tradeoff questions before planning began; those resolutions are the Key Design Decisions listed above. Two rounds of code review post-implementation: an initial round flagged three Important issues (unnecessary cast, weak codec-test, ambiguous README wording); all three fixed in `cdbfd27`. Final pre-merge review: approved.
+
+Scope boundary set at design time and still current: fresh external join by a *new* DID (no live inviter), the `proposeAddExternal` flow, and the distribution mechanism for `GroupInfo` were all deliberately deferred — see Follow-ups below. Capability chains are not re-validated on rejoin: the caller's stored `MemberCredential` is taken as given, because it was already validated when originally accepted during `processWelcome`. Re-validation would only matter if storage tampering were in the threat model, which it is not.
 
 ## Outcomes
 


### PR DESCRIPTION
`completed/2026-04-20-mls-external-rejoin.complete.md` pointed at `docs/superpowers/specs/2026-04-20-mls-external-rejoin-design.md` for its seven design-review resolutions. That spec is deleted when a plan completes, so the link has been dead since the day it was written.

It was also redundant: those seven resolutions are the **Key Design Decisions** bullets sitting directly above the reference. Now points there.

While recovering the deleted spec from git history to check nothing was lost, two decisions turned out to exist *only* in it, so they're inlined now:

- the scope boundary (fresh external join by a new DID, `proposeAddExternal`, and `GroupInfo` distribution were all deliberately deferred)
- why capability chains aren't re-validated on rejoin (the credential was already validated during `processWelcome`; re-validation would only matter under a storage-tampering threat model, which is out of scope)

The four remaining `docs/superpowers/` mentions under `docs/agents/plans/` are **not** dangling and are left alone — they read "previously at `<path>` (deleted on completion; preserved in git history)". The path there is what makes the spec recoverable via `git log --diff-filter=D -- <path>`, which is exactly how I recovered this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LziyEpnxbcQw8XYD4JqE6j